### PR TITLE
Rewriting of cannabis-weight-flow.spec.js for integration tests

### DIFF
--- a/__checks__/knit-agency/BCCS/B2B/integration-tests/add-items-from-cart.spec.js
+++ b/__checks__/knit-agency/BCCS/B2B/integration-tests/add-items-from-cart.spec.js
@@ -6,7 +6,8 @@ import {
   AddProductsFromHeaderSearch,
   visitTheme,
   waitForPageToFullyRender,
-  proceedToCart
+  proceedToCart,
+  inCartSearch
 } from '../../utilities/utils';
 /*
 Feature: Adding items to the cart
@@ -38,9 +39,7 @@ const skusText = [...items, extraItem].map(i => (i.query));
 
 const addItemFromInsideCart = async (page) => {
   await proceedToCart(page);
-  await waitForPageToFullyRender(page, 1000);
-  await page.locator('button:text("Add a product to order")').click();
-  await page.getByPlaceholder('Add a product to order').fill(extraItem.query);
+  await inCartSearch(page, true, extraItem.query);
   await waitForPageToFullyRender(page, 1000);
   await page.locator('#search-cart').getByRole('link').first().click();
 }

--- a/__checks__/knit-agency/BCCS/B2B/integration-tests/cannabis-weight-flow.spec.js
+++ b/__checks__/knit-agency/BCCS/B2B/integration-tests/cannabis-weight-flow.spec.js
@@ -40,25 +40,25 @@ const route = generateThemeRoute(
   THEME_ID
 );
 
-const cdf_product_sku = '1017557';
+const cdfProductSku = '1017557';
 
 // Elements order within array is important
-const search_items_1 = [
-  { query: cdf_product_sku, quantity: '1' },
+const firstSetSearchItems = [
+  { query: cdfProductSku, quantity: '1' },
   { query: '1010834', quantity: '1' },
   { query: '1019074', quantity: '1' }
 ];
 
 // Elements order within array is important
-const search_items_2 = [
+const secondSetSearchItems = [
   { query: '1010834', quantity: '1' },
-  { query: cdf_product_sku, quantity: '1' },
+  { query: cdfProductSku, quantity: '1' },
   { query: '1019074', quantity: '1' },
 ];
 
-const header_search_skus = [search_items_1, search_items_2];
+const headerSearchSkus = [firstSetSearchItems, secondSetSearchItems];
 
-const inline_cart_skus = ['1023639'];
+const inlineCartSkus = ['1023639'];
 
 // Stateful values:
 let cartTotalCannabisWeight; // NOTE: Used to compare cart and checkout values
@@ -70,7 +70,7 @@ test.describe('Cannabis Weight is tallied correctly', () => {
     await loginAsCustomer(page, '', route, STORE_PASSWORD);
   });
 
-  header_search_skus.forEach((items, index) => {
+  headerSearchSkus.forEach((items, index) => {
     test(`${index} - Order: ${items.length}, building cart`, async ({ page }) => {
       await test.step('Cart checks', async () => {
         let pristine = true;
@@ -79,7 +79,7 @@ test.describe('Cannabis Weight is tallied correctly', () => {
         await proceedToCart(page);
         await expect(page.locator('.productlistitem')).toHaveCount(items.length);
 
-        inline_cart_skus.forEach(sku => {
+        inlineCartSkus.forEach(sku => {
           inCartSearch(page, pristine, sku);
           actionQuickLook(page);
           atcQuickShop(page);

--- a/__checks__/knit-agency/BCCS/B2B/integration-tests/cannabis-weight-flow.spec.js
+++ b/__checks__/knit-agency/BCCS/B2B/integration-tests/cannabis-weight-flow.spec.js
@@ -1,0 +1,101 @@
+import { THEME_ID, B2B_DEV_URL, STORE_PASSWORD } from '../../utilities/constants';
+import { test, expect } from '@playwright/test';
+import {
+  generateThemeRoute,
+  loginAsCustomer,
+  AddProductsFromHeaderSearch,
+  visitTheme,
+  inCartSearch,
+  actionQuickLook,
+  atcQuickShop,
+  proceedToCheckout,
+  waitForPageToFullyRender,
+  proceedToCart
+} from "../../utilities/utils";
+/*
+Feature: Cannabis Weight is totalled correctly
+  I want to test that the Cart and Checkout consistently set the same cannabis weight attribute.
+
+  This includes testing the initial values when the page is first rendered
+  And testing values that are updated and don't require refreshing the page
+
+  The scenario will be looped with order item composition.
+
+  Scenarios:
+    1: CDF product is first, follow by other items
+    2: Items and a CDF product somewhere in the middle of the order
+
+  Scenario loop:
+    Given I am on the homepage with a few items already in the cart
+    When going to the Cart, expect the count to be correct
+    When adding additional items, via the Cart inline search, display the correct updated weight
+    Then proceeding the Checkout should display the same result from the Cart
+
+*/
+
+const route = generateThemeRoute(
+  '',
+  true,
+  B2B_DEV_URL,
+  THEME_ID
+);
+
+const cdf_product_sku = '1017557';
+
+// Elements order within array is important
+const search_items_1 = [
+  { query: cdf_product_sku, quantity: '1' },
+  { query: '1010834', quantity: '1' },
+  { query: '1019074', quantity: '1' }
+];
+
+// Elements order within array is important
+const search_items_2 = [
+  { query: '1010834', quantity: '1' },
+  { query: cdf_product_sku, quantity: '1' },
+  { query: '1019074', quantity: '1' },
+];
+
+const header_search_skus = [search_items_1, search_items_2];
+
+const inline_cart_skus = ['1023639'];
+
+// Stateful values:
+let cartTotalCannabisWeight; // NOTE: Used to compare cart and checkout values
+let checkoutTotalCannabisWeight;
+
+test.describe('Cannabis Weight is tallied correctly', () => {
+  test.beforeEach(async ({ page }) => {
+    await visitTheme(page);
+    await loginAsCustomer(page, '', route, STORE_PASSWORD);
+  });
+
+  header_search_skus.forEach((items, index) => {
+    test(`${index} - Order: ${items.length}, building cart`, async ({ page }) => {
+      await test.step('Cart checks', async () => {
+        let pristine = true;
+
+        await AddProductsFromHeaderSearch(page, items);
+        await proceedToCart(page);
+        await expect(page.locator('.productlistitem')).toHaveCount(items.length);
+
+        inline_cart_skus.forEach(sku => {
+          inCartSearch(page, pristine, sku);
+          actionQuickLook(page);
+          atcQuickShop(page);
+          pristine = !pristine;
+        });
+
+        await compareCannabisTotalWeights(page);
+      });
+    });
+  });
+});
+
+const compareCannabisTotalWeights = async (page) => {
+  await waitForPageToFullyRender(page, 8000);
+  cartTotalCannabisWeight = await page.locator('[data-cart-weight-cannabis]').textContent();
+  await proceedToCheckout(page);
+  checkoutTotalCannabisWeight = await page.locator('[data-cart-weight-cannabis]').textContent();
+  expect(checkoutTotalCannabisWeight).toEqual(cartTotalCannabisWeight);
+}

--- a/__checks__/knit-agency/BCCS/utilities/utils.js
+++ b/__checks__/knit-agency/BCCS/utilities/utils.js
@@ -254,7 +254,8 @@ const waitForPageToFullyRender = async (page, timeout, message = '') => {
 
 /**
  * Add to Cart from Cart's inline search component
- *
+ * @param page - page instance used for test
+ * @param {boolean} pristine - If true adds step that activates search bar
  * @param {string} query - Accepts any string for header search.
  */
 const inCartSearch = async (page, pristine, query = '') => {

--- a/__checks__/knit-agency/BCCS/utilities/utils.js
+++ b/__checks__/knit-agency/BCCS/utilities/utils.js
@@ -115,7 +115,7 @@ const AddProductsFromHeaderSearch = async (page, cartList = []) => {
 		await page.waitForSelector(".search-flydown", { timeout: 5000 });
 		await expect(page.locator(".search-flydown").first()).toBeVisible(true);
 		await page.waitForSelector(".search-flydown--results", { timeout: 5000 });
-		await expect(page.locator(".search-flydown--results")).toBeVisible(true);
+		await expect(page.locator(".search-flydown--results").first()).toBeVisible(true);
 		await page.locator(".productlist--item a").first().click();
 		await page
 			.locator(".form-field--qty-input input")
@@ -242,9 +242,47 @@ const clearLocalStorage = async (page) => {
 //   });
 // });
 
+/**
+ *
+ * @param {number} timeout - timeout duration in miliseconds
+ * @param {string} message - future use may allow for additional information to be displayed
+ * @returns native timeout method for the page object
+ */
 const waitForPageToFullyRender = async (page, timeout, message = '') => {
 	return page.waitForTimeout(timeout);
 }
+
+/**
+ * Add to Cart from Cart's inline search component
+ *
+ * @param {string} query - Accepts any string for header search.
+ */
+const inCartSearch = async (page, pristine, query = '') => {
+	await waitForPageToFullyRender(page, 1500);
+	if (pristine) await page.locator('.product-inline-search-toggle[data-live-search-toggle]').click();
+	await page.getByPlaceholder('Add a product to order').fill(query);
+}
+
+/**
+ * Access Quick Shop modal by clicking on the Quick Look button in the first search result item
+ */
+const actionQuickLook = async (page) => {
+	await page.locator('#search-cart').getByRole('link').first().hover();
+	await page.getByRole('button', { name: 'Quick look' }).first().click();
+}
+
+/**
+ * Add to Cart through Quick Shop modal
+ */
+const atcQuickShop = async (page) => {
+	await waitForPageToFullyRender(page, 1500);
+
+	await expect(page.locator('.modal--quickshop-full[data-modal-container]')).toBeVisible(true);
+	await page.locator('#product-quantity-input').fill('1');
+	await page.getByRole('button', { name: 'Add to order' }).click();
+	await page.waitForSelector('.modal-close[data-modal-close]', { timeout: 1000 });
+	await page.locator('.modal-close[data-modal-close]').click();
+};
 
 export {
 	insertParam,
@@ -264,5 +302,8 @@ export {
 	proceedToCart,
 	getLocalStorage,
 	clearLocalStorage,
-	waitForPageToFullyRender
+	waitForPageToFullyRender,
+	inCartSearch,
+	actionQuickLook,
+	atcQuickShop
 };


### PR DESCRIPTION
|                        Productive Ticket                        |
| :-----------------------------------------------------------: |
| [**4676245**](https://app.productive.io/23591-knit-agency/tasks/4676245) |

#### What is this change?

Rewriting of  cannabis-weight-flow.spec.js for the B2B integration tests

Test will populate cart from main page with 3 items.

It will evaluate the amount of line items and then proceed to add an additional one from the in-cart search bar.

Then it will evaluate the total cannabis weight and store the value in variable.

After going to the checkout view, it will again evaluate the displayed total cannabis weight and compare it against the previous one. 

It will run tests twice, given an array with two different sets of items (different order)
